### PR TITLE
Potential fix for code scanning alert no. 1: Failure to use secure cookies

### DIFF
--- a/backend/auth_service/app/api/endpoints.py
+++ b/backend/auth_service/app/api/endpoints.py
@@ -89,7 +89,7 @@ async def login_for_access_token(
     response.set_cookie(
         key="csrf_access_token", 
         value=csrf_token, 
-        httponly=False, 
+        httponly=True, 
         samesite="lax", 
         secure=SECURE_COOKIE, 
         path="/",


### PR DESCRIPTION
Potential fix for [https://github.com/dislovemartin/ACGS/security/code-scanning/1](https://github.com/dislovemartin/ACGS/security/code-scanning/1)

To fix the issue, the `HttpOnly` attribute for the `csrf_access_token` cookie should be set to `True`. This ensures that the cookie is not accessible to JavaScript, mitigating the risk of it being stolen via an XSS attack. If the application requires the CSRF token to be accessible to JavaScript, an alternative approach (e.g., storing the token in a different way) should be considered.

The fix involves modifying the `response.set_cookie` call for the `csrf_access_token` on line 89 to set `httponly=True`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
