### PR TITLE
Potential fix for code scanning alert no. 2: Failure to use secure cookies

### DIFF
--- a/backend/auth_service/app/api/endpoints.py
+++ b/backend/auth_service/app/api/endpoints.py
@@ -169,7 +169,7 @@ async def refresh_access_token(
     response.set_cookie(
         key="csrf_access_token", 
         value=new_csrf_token, 
-        httponly=False, 
+        httponly=True, 
         samesite="lax", 
         secure=SECURE_COOKIE, 
         path="/",


### PR DESCRIPTION
Potential fix for [https://github.com/dislovemartin/ACGS/security/code-scanning/2](https://github.com/dislovemartin/ACGS/security/code-scanning/2)

To fix the issue, the `httponly` attribute of the `csrf_access_token` cookie should be set to `True`. This ensures that the cookie is not accessible to JavaScript, reducing the risk of it being stolen in the event of an XSS attack. The change should be made on line 172 of the code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
