### PR TITLE
feat: Add GitHub Actions workflow for Docker image builds

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,4 +1,6 @@
 name: Docker images
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,31 @@
+name: Docker images
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: dev
+            file: .devcontainer/Dockerfile
+            context: .
+            image: ghcr.io/${{ github.repository }}/dev
+          - name: auth
+            file: auth_service/Dockerfile
+            context: auth_service
+            image: ghcr.io/${{ github.repository }}/auth
+          - name: backend
+            file: backend/ac_service/Dockerfile
+            context: backend/ac_service
+            image: ghcr.io/${{ github.repository }}/backend
+          - name: frontend
+            file: frontend/Dockerfile
+            context: frontend
+            image: ghcr.io/${{ github.repository }}/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: |
+          docker buildx build             -f ${{ matrix.file }}             -t ${{ matrix.image }}:pr-${{ github.sha }}             --load             ${{ matrix.context }}

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,6 +1,4 @@
 name: Docker images
-permissions:
-  contents: read
 
 on: [push, pull_request]
 
@@ -13,19 +11,19 @@ jobs:
           - name: dev
             file: .devcontainer/Dockerfile
             context: .
-            image: ghcr.io/${{ github.repository }}/dev
+            image: ghcr.io/${{ github.repository | toLower }}/dev
           - name: auth
             file: auth_service/Dockerfile
             context: auth_service
-            image: ghcr.io/${{ github.repository }}/auth
+            image: ghcr.io/${{ github.repository | toLower }}/auth
           - name: backend
             file: backend/ac_service/Dockerfile
             context: backend/ac_service
-            image: ghcr.io/${{ github.repository }}/backend
+            image: ghcr.io/${{ github.repository | toLower }}/backend
           - name: frontend
             file: frontend/Dockerfile
             context: frontend
-            image: ghcr.io/${{ github.repository }}/frontend
+            image: ghcr.io/${{ github.repository | toLower }}/frontend
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow (`image-build.yml`) to automatically build Docker images for the dev, auth, backend, and frontend services upon push or pull request.

This workflow is intended to address Task T0B by validating the Docker images via CI.

Note: Due to persistent file visibility issues I've been experiencing, the `.devcontainer/Dockerfile` may not have been successfully committed. If so, the 'dev' image build in this workflow may fail. The fix for `auth_service/Dockerfile` should be included.