### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/backend/gs_service/app/api/v1/constitutional_synthesis.py
+++ b/backend/gs_service/app/api/v1/constitutional_synthesis.py
@@ -85,6 +85,12 @@ async def analyze_constitutional_context_endpoint(
             auth_token=auth_token
         )
         
+        if "error" in constitutional_context:
+            return {
+                "context": context,
+                "constitutional_context": None,
+                "error": constitutional_context["error"]
+            }
         return {
             "context": context,
             "constitutional_context": constitutional_context,

--- a/backend/gs_service/app/core/constitutional_prompting.py
+++ b/backend/gs_service/app/core/constitutional_prompting.py
@@ -78,7 +78,7 @@ CONSTITUTIONAL COMPLIANCE REQUIREMENTS:
                 "category": category,
                 "principles": [],
                 "principle_count": 0,
-                "error": str(e)
+                "error": "An internal error occurred while building the constitutional context."
             }
 
     async def _fetch_relevant_principles(


### PR DESCRIPTION
Potential fix for [https://github.com/dislovemartin/ACGS/security/code-scanning/9](https://github.com/dislovemartin/ACGS/security/code-scanning/9)

To fix the issue, the application should avoid exposing the raw error message (`str(e)`) to the user. Instead, it should return a generic error message while logging the detailed error information on the server. This ensures that sensitive information is not leaked to external users while still allowing developers to debug issues using server-side logs.

**Steps to implement the fix:**
1. Modify the `build_constitutional_context` method in `backend/gs_service/app/core/constitutional_prompting.py` to return a generic error message instead of the raw exception details in the `"error"` key.
2. Ensure that the detailed error message (`str(e)`) is logged on the server using `logger.error`.
3. Update the `/analyze-context` endpoint in `backend/gs_service/app/api/v1/constitutional_synthesis.py` to handle the modified structure of the `constitutional_context` dictionary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
