### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,9 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dislovemartin/ACGS/security/code-scanning/10](https://github.com/dislovemartin/ACGS/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uploads SARIF files to the Security tab. Therefore, the `contents: read` and `security-events: write` permissions are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
