### PR TITLE
Add additional token tests

### DIFF
--- a/src/backend/auth_service/app/tests/test_token.py
+++ b/src/backend/auth_service/app/tests/test_token.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+from freezegun import freeze_time
+
 import pytest
 from ..core import security  # Assuming your security functions are here
 from ..core.config import settings
@@ -10,15 +12,20 @@ from ..core.config import settings
 def test_create_access_token():
     subject = "testuser@example.com"
     expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    token = security.create_access_token(subject=subject, expires_delta=expires)
+    token, jti = security.create_access_token(
+        subject=subject, user_id=1, roles=["user"], expires_delta=expires
+    )
     assert isinstance(token, str)
+    assert isinstance(jti, str)
 
 
 def test_verify_access_token_valid():
     subject = "testuser@example.com"
     expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    token = security.create_access_token(subject=subject, expires_delta=expires)
-    payload = security.verify_token(token)
+    token, _ = security.create_access_token(
+        subject=subject, user_id=1, roles=["user"], expires_delta=expires
+    )
+    payload = security.verify_token_and_get_payload(token)
     assert payload is not None
     if payload:  # Type guard
         assert payload.sub == subject
@@ -29,12 +36,12 @@ def test_verify_access_token_expired():
     subject = "testuser@example.com"
     # Create a token that has already expired
     expired_delta = timedelta(minutes=-settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    expired_token = security.create_access_token(
-        subject=subject, expires_delta=expired_delta
+    expired_token, _ = security.create_access_token(
+        subject=subject, user_id=1, roles=["user"], expires_delta=expired_delta
     )
 
     with pytest.raises(security.HTTPException) as excinfo:
-        security.verify_token(expired_token)
+        security.verify_token_and_get_payload(expired_token)
     # This depends on how security.verify_token raises exceptions
     # for expired tokens. Assuming HTTPException with status 401.
     assert excinfo.value.status_code == 401
@@ -44,12 +51,14 @@ def test_verify_access_token_expired():
 def test_verify_access_token_invalid_signature():
     subject = "testuser@example.com"
     expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    token = security.create_access_token(subject=subject, expires_delta=expires)
+    token, _ = security.create_access_token(
+        subject=subject, user_id=1, roles=["user"], expires_delta=expires
+    )
     # Tamper with the token
     invalid_token = token + "tampered"
 
     with pytest.raises(security.HTTPException) as excinfo:
-        security.verify_token(invalid_token)
+        security.verify_token_and_get_payload(invalid_token)
     # Assuming HTTPException with status 401 for signature mismatch.
     assert excinfo.value.status_code == 401
     # assert "Could not validate credentials" in str(excinfo.value.detail)
@@ -65,8 +74,42 @@ def test_password_hashing_and_verification():
     assert security.verify_password("wrongpassword", hashed_password) is False
 
 
-# TODO:
-# - Test for tokens with different scopes if applicable.
-# - Test for tokens with non-ASCII characters in subject if relevant.
-# - Consider edge cases for token expiry (e.g., token created just before
-#   expiry).
+def test_token_with_additional_scopes():
+    subject = "scopeduser@example.com"
+    roles = ["user", "admin", "auditor"]
+    token, _ = security.create_access_token(
+        subject=subject, user_id=2, roles=roles, expires_delta=timedelta(minutes=5)
+    )
+
+    payload = security.verify_token_and_get_payload(token)
+    assert payload is not None
+    if payload:
+        assert payload.roles == roles
+
+
+def test_token_with_non_ascii_subject():
+    subject = "测试用户@example.com"
+    token, _ = security.create_access_token(
+        subject=subject, user_id=3, roles=["user"], expires_delta=timedelta(minutes=5)
+    )
+
+    payload = security.verify_token_and_get_payload(token)
+    assert payload is not None
+    if payload:
+        assert payload.sub == subject
+
+
+def test_token_created_right_before_expiry():
+    subject = "edgecase@example.com"
+    with freeze_time("2024-01-01 00:00:00") as frozen:
+        token, _ = security.create_access_token(
+            subject=subject,
+            user_id=4,
+            roles=["user"],
+            expires_delta=timedelta(seconds=1),
+        )
+        frozen.tick(delta=timedelta(seconds=0.9))
+        payload = security.verify_token_and_get_payload(token)
+        assert payload is not None
+        if payload:
+            assert payload.sub == subject


### PR DESCRIPTION
## Summary
- improve token test coverage
- handle unicode subjects and scoped tokens
- verify tokens created just before expiry

## Testing
- `pytest src/backend/auth_service/app/tests/test_token.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841be80f1308328a6accb98ce2abff2