### PR TITLE
Add configurable cookie security

### DIFF
--- a/src/backend/auth_service/README.md
+++ b/src/backend/auth_service/README.md
@@ -35,3 +35,10 @@ Refer to `requirements.txt` for specific package versions. Core shared models an
 ## Local Development
 
 For general setup, refer to the main project `README.md` and `docs/developer_guide.md`. This service can be run using Uvicorn: `uvicorn app.main:app --host 0.0.0.0 --port 8000`.
+
+## Configuration
+
+The service reads an `APP_ENV` environment variable to decide whether cookies
+should be marked as `Secure`. Set `APP_ENV=production` in production
+deployments so authentication cookies are only sent over HTTPS. Any other value
+(or if the variable is unset) disables the flag for local development.

--- a/src/backend/auth_service/app/api/endpoints.py
+++ b/src/backend/auth_service/app/api/endpoints.py
@@ -1,11 +1,12 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Response, Request
-from fastapi.responses import JSONResponse # Added JSONResponse import
+from fastapi.responses import JSONResponse  # Added JSONResponse import
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
 import secrets
 from datetime import timedelta
 from typing import Optional
 from fastapi_csrf_protect import CsrfProtect
+import os
 
 from .. import crud, schemas
 from shared import models
@@ -15,10 +16,10 @@ from ..core.limiter import limiter # Import the limiter instance
 
 router = APIRouter()
 
-# Determine Secure flag based on environment (e.g., if APP_ENV is 'production')
-# For simplicity, let's assume Secure=True should be used if not explicitly in dev.
-# In a real app, this would be based on a config setting.
-SECURE_COOKIE = True # TODO: Make this configurable, e.g., os.getenv("APP_ENV") == "production" 
+# Determine Secure flag based on environment. If ``APP_ENV`` is set to
+# ``production`` the authentication cookies will include the ``Secure``
+# attribute. Any other value defaults to development behaviour.
+SECURE_COOKIE = os.getenv("APP_ENV", "development").lower() == "production"
 
 # This dependency will be moved to security.py or a similar place
 # For now, defined here to illustrate the change in get_current_user's signature

--- a/tests/unit/test_secure_cookie_env.py
+++ b/tests/unit/test_secure_cookie_env.py
@@ -1,0 +1,39 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+import pytest
+
+
+def reload_endpoints():
+    """Reload endpoints with minimal dependencies."""
+    # Provide placeholder for missing security helper
+    import src.backend.auth_service.app.core.security as security
+    if not hasattr(security, "get_current_active_user_from_cookie"):
+        setattr(security, "get_current_active_user_from_cookie", lambda: None)
+
+    # Ensure the schemas module refers to the actual schemas.py file
+    root = Path(__file__).resolve().parents[2]
+    schema_path = root / "src/backend/auth_service/app/schemas.py"
+    spec = importlib.util.spec_from_file_location("temp_schemas", schema_path)
+    schemas_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(schemas_mod)
+    sys.modules["src.backend.auth_service.app.schemas"] = schemas_mod
+
+    import src.backend.auth_service.app.api.endpoints as endpoints
+    importlib.reload(endpoints)
+    return endpoints
+
+
+@pytest.mark.unit
+def test_secure_cookie_development(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "development")
+    endpoints = reload_endpoints()
+    assert endpoints.SECURE_COOKIE is False
+
+
+@pytest.mark.unit
+def test_secure_cookie_production(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "production")
+    endpoints = reload_endpoints()
+    assert endpoints.SECURE_COOKIE is True


### PR DESCRIPTION
## Summary
- make cookie security depend on `APP_ENV` in auth service endpoints
- document new `APP_ENV` variable
- test that cookie `Secure` flag toggles between development and production

## Testing
- `pytest tests/unit/test_secure_cookie_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841be7f47548328ad9f6d72a76e9bf8