### PR TITLE
Fix placeholder policy in QEC tests

### DIFF
--- a/tests/test_qec_enhancements.py
+++ b/tests/test_qec_enhancements.py
@@ -79,7 +79,7 @@ class TestConstitutionalDistanceCalculator:
             name="Vague Principle",
             description="AI should be appropriate and reasonable when possible.",
             category="General",
-            policy_code="# TODO: implement policy"
+            policy_code="package test.low_quality\n" "default allow = false\n" "allow { input.valid }"
         )
     
     def test_calculate_score_high_quality(self):


### PR DESCRIPTION
## Summary
- replace the placeholder policy in `test_qec_enhancements`

## Testing
- `pytest tests/test_qec_enhancements.py::TestConstitutionalDistanceCalculator::test_calculate_score_low_quality -q`

------
https://chatgpt.com/codex/tasks/task_e_684238f63404832884d93c93ce3d60c9