### PR TITLE
Replace cp system calls with shutil copytree

### DIFF
--- a/src/dgm-best_swe_agent/DGM_outer.py
+++ b/src/dgm-best_swe_agent/DGM_outer.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import math
 import os
+import shutil
 import random
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed, TimeoutError
 
@@ -28,9 +29,20 @@ def initialize_run(output_dir, prevrun_dir=None, polyglot=False):
     initial_folder_name = 'initial' if not polyglot else 'initial_polyglot'
     if not prevrun_dir and not os.path.exists(f"{output_dir}/{initial_folder_name}"):
         if os.path.exists(initial_folder_name):
-            os.system(f"cp -r {initial_folder_name}/ {output_dir}/initial")
+            try:
+                shutil.copytree(
+                    initial_folder_name,
+                    os.path.join(output_dir, "initial"),
+                    dirs_exist_ok=True,
+                )
+            except OSError as e:
+                raise RuntimeError(
+                    f"Failed to copy {initial_folder_name} to {output_dir}/initial: {e}"
+                )
         else:
-            raise RuntimeError("Error: Need to properly configure evaluation results for the initial version.")
+            raise RuntimeError(
+                "Error: Need to properly configure evaluation results for the initial version."
+            )
     
     return archive, start_gen_num
 

--- a/src/dgm-best_swe_agent/self_improve_step.py
+++ b/src/dgm-best_swe_agent/self_improve_step.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import json
 import os
+import shutil
 import docker
 
 from llm import create_client, get_response_from_llm, extract_json_between_markers
@@ -431,7 +432,16 @@ def main():
     args = parser.parse_args()
 
     # Copy cached initial version into experiment dir
-    os.system(f"cp -r initial/ {args.output_dir}")
+    try:
+        shutil.copytree(
+            "initial",
+            args.output_dir,
+            dirs_exist_ok=True,
+        )
+    except OSError as e:
+        raise RuntimeError(
+            f"Failed to copy initial directory to {args.output_dir}: {e}"
+        )
 
     metadata = self_improve(
         parent_commit=args.parent_commit,


### PR DESCRIPTION
## Summary
- remove shell `cp` usage in favor of `shutil.copytree`
- add error handling when copying initial directories

## Testing
- `pytest -q src/dgm-best_swe_agent/tests/test_bash_tool.py::TestBashTool::test_simple_command`
- `python -m py_compile src/dgm-best_swe_agent/DGM_outer.py src/dgm-best_swe_agent/self_improve_step.py`

------
https://chatgpt.com/codex/tasks/task_e_684238f408488328b9cbc4a4c5aa7d50