### PR TITLE
Avoid shared ModelConfig mutation

### DIFF
--- a/src/backend/shared/ai_model_service.py
+++ b/src/backend/shared/ai_model_service.py
@@ -12,6 +12,7 @@ import logging
 from typing import Dict, List, Optional, Any, Union
 from enum import Enum
 from dataclasses import dataclass
+import dataclasses
 try:
     from .utils import get_config
 except ImportError:
@@ -179,12 +180,15 @@ class AIModelService:
         if model_name:
             if model_name not in self.models:
                 raise ValueError(f"Unknown model: {model_name}")
-            model_config = self.models[model_name]
+            selected_config = self.models[model_name]
         elif role:
-            model_config = self._get_model_by_role(role)
+            selected_config = self._get_model_by_role(role)
         else:
-            model_config = self.models['primary']
-        
+            selected_config = self.models['primary']
+
+        # Clone model configuration to avoid mutating shared instance
+        model_config = dataclasses.replace(selected_config)
+
         # Override parameters if provided
         if max_tokens:
             model_config.max_tokens = max_tokens

--- a/tests/unit/services/test_ai_model_service_concurrency.py
+++ b/tests/unit/services/test_ai_model_service_concurrency.py
@@ -1,0 +1,66 @@
+import asyncio
+import pytest
+
+# Import AIModelService utilities
+try:
+    from shared.ai_model_service import (
+        get_ai_model_service,
+        reset_ai_model_service,
+    )
+except ImportError:  # fallback if path not set
+    from src.backend.shared.ai_model_service import (
+        get_ai_model_service,
+        reset_ai_model_service,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_text_does_not_mutate_config():
+    await reset_ai_model_service()
+    service = await get_ai_model_service()
+
+    original_max_tokens = service.models["primary"].max_tokens
+    original_temperature = service.models["primary"].temperature
+
+    async def call_one():
+        return await service.generate_text(
+            "one", max_tokens=50, temperature=0.9
+        )
+
+    async def call_two():
+        return await service.generate_text(
+            "two", max_tokens=60, temperature=0.1
+        )
+
+    await asyncio.gather(call_one(), call_two())
+
+    assert service.models["primary"].max_tokens == original_max_tokens
+    assert service.models["primary"].temperature == original_temperature
+
+@pytest.mark.asyncio
+async def test_concurrent_generation_federated_does_not_mutate_config():
+    from src.backend.federated_service.shared.ai_model_service import (
+        get_ai_model_service as get_fed_service,
+        reset_ai_model_service as reset_fed_service,
+    )
+
+    await reset_fed_service()
+    service = await get_fed_service()
+
+    original_max_tokens = service.models["primary"].max_tokens
+    original_temperature = service.models["primary"].temperature
+
+    async def call_one():
+        return await service.generate_text(
+            "f-one", max_tokens=40, temperature=0.8
+        )
+
+    async def call_two():
+        return await service.generate_text(
+            "f-two", max_tokens=70, temperature=0.2
+        )
+
+    await asyncio.gather(call_one(), call_two())
+
+    assert service.models["primary"].max_tokens == original_max_tokens
+    assert service.models["primary"].temperature == original_temperature


### PR DESCRIPTION
## Summary
- clone ModelConfig before overriding parameters in `AIModelService.generate_text`
- ensure federated service uses same approach
- test that concurrent calls don't mutate shared configs

## Testing
- `pytest tests/unit/services/test_ai_model_service_concurrency.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684238f34f5083288cabb05dae1eaa1b