### PR TITLE
Update dataset handling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ The AI Compliance Governance System - Policy Generation Platform (ACGS-PGP) is a
    curl http://localhost:8000/health
    ```
 
+### Policy Corpus Setup
+
+The policy corpus under `data/principle-policy-corpus` includes
+profiles from the [NIST OSCAL project](https://github.com/usnistgov/OSCAL).
+These files total more than 100 MB. To keep the repository small, you can
+store them using [Git LFS](https://git-lfs.github.com/) or host them on an
+external storage service such as S3.
+
+If the directory `nist-oscal-profiles` is missing, retrieve the latest
+profiles and place them under `data/principle-policy-corpus`:
+
+```bash
+git clone https://github.com/usnistgov/oscal-content.git tmp-oscal
+mkdir -p data/principle-policy-corpus/nist-oscal-profiles
+cp -r tmp-oscal/examples/* data/principle-policy-corpus/nist-oscal-profiles/
+rm -rf tmp-oscal
+```
+
 ## Development
 
 ### Project Structure

--- a/data/principle-policy-corpus/README.md
+++ b/data/principle-policy-corpus/README.md
@@ -62,3 +62,23 @@ Each policy is saved in the following format:
   "alignment_notes": ""
 }
 ```
+
+## Managing NIST OSCAL Profiles
+
+The `nist-oscal-profiles` directory contains official OSCAL example
+profiles from NIST and is over 100 MB. To reduce repository size, store
+these files in [Git LFS](https://git-lfs.github.com/) or host them on an
+external service (e.g., S3).
+
+If the directory is missing, download the profiles manually:
+
+```bash
+git clone https://github.com/usnistgov/oscal-content.git tmp-oscal
+mkdir -p nist-oscal-profiles
+cp -r tmp-oscal/examples/* nist-oscal-profiles/
+rm -rf tmp-oscal
+```
+
+Ensure the profiles are located at
+`data/principle-policy-corpus/nist-oscal-profiles` before running the
+parser.


### PR DESCRIPTION
## Summary
- document how to manage large NIST OSCAL profiles
- add notes in the policy corpus README for downloading the corpus if not stored in the repo

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68424f10c72c83289821c0b9f8c958bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed setup instructions for managing large NIST OSCAL profile files in the policy corpus, including recommendations for using Git LFS or external storage and step-by-step download procedures.
  - Updated guidance to ensure users have the required profiles available before running the parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->