### PR TITLE
Fix CodeQL SARIF upload action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3.25.15
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -45,6 +45,6 @@ jobs:
       uses: microsoft/security-devops-action@v1.12.0
       id: msdo
     - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@v3.25.15
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -105,7 +105,7 @@ jobs:
           exit-code: '1'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3.25.15
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- update CodeQL upload action to use supported `v3` tag instead of old 3.25.15 patch

## Testing
- `bash run_tests.sh` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68427bb5dfa48328a889d898d3e20aae