### PR TITLE
Update test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,23 @@ ACGS-PGP/
 ```
 
 ### Running Tests
-```bash
-# Run all tests
-pytest
+To run the test suite locally you need the packages listed in
+`requirements-test.txt`. The recommended workflow is:
 
+```bash
+# Create and activate a virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install test dependencies
+pip install -r requirements-test.txt
+
+# Execute the full test suite
+./run_tests.sh
+```
+
+You can also invoke `pytest` directly:
+```bash
 # Legacy integration scripts (require running services)
 ACGS_INTEGRATION=1 pytest tests/integration/legacy
 


### PR DESCRIPTION
## Summary
- document how to install test dependencies in a virtualenv
- describe using `./run_tests.sh` before direct `pytest` usage

## Testing
- `./run_tests.sh` *(fails: some tests errored)*

------
https://chatgpt.com/codex/tasks/task_e_6843201b28748328b5856ef890490bce