### PR TITLE
Fix changed-files action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: actions/changed-files@v44 # Using a specific version
+        uses: actions/changed-files@v4 # Using a valid version
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # We only care about changes in these paths for running tests


### PR DESCRIPTION
## Summary
- fix version reference for `actions/changed-files`

## Testing
- `python -m pytest --version`
- `pytest -k "nothing" -s` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684328e73aec8328a89682a464aae050