### PR TITLE
Fix changed-files action path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: actions/changed-files@v4 # Using a valid version
+        uses: tj-actions/changed-files@v36
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # We only care about changes in these paths for running tests


### PR DESCRIPTION
## Summary
- use `tj-actions/changed-files@v36` in CI workflow

## Testing
- `pytest tests/test_centralized_configuration.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68432d9eda4c83289a60f88515fb868e