### PR TITLE
Add jq check to staging deployment script

### DIFF
--- a/scripts/phase3_staging_deployment.sh
+++ b/scripts/phase3_staging_deployment.sh
@@ -6,6 +6,17 @@
 
 set -euo pipefail
 
+# Ensure jq is available for JSON processing
+if ! command -v jq &> /dev/null; then
+    echo -e "\033[0;31m[ERROR]\033[0m jq not found. Attempting to install..."
+    if apt-get update && apt-get install -y jq; then
+        echo -e "\033[0;32m[SUCCESS]\033[0m jq installed successfully"
+    else
+        echo -e "\033[0;31m[ERROR]\033[0m jq is required but could not be installed"
+        exit 1
+    fi
+fi
+
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## Summary
- add check at the top of `phase3_staging_deployment.sh` to ensure jq is present
- attempt installation if jq is missing
- run deployment script to confirm it moves past the jq check

## Testing
- `bash scripts/phase3_staging_deployment.sh`
- `pip install -r requirements-test.txt` *(fails: Operation cancelled)*
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68433a8fcda48328937e1e07b343ce69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an automatic check and installation for the required `jq` tool during deployment, with clear success or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->