### PR TITLE
Fix LaTeX job by installing acmart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,8 @@ jobs:
       - name: Install TeX Live
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+          sudo apt-get install -y --no-install-recommends \
+            texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-publishers
 
       - name: Compile LaTeX document
         run: |

--- a/docs/research/ACGS-PGP_Framework/manual_compilation_guide.md
+++ b/docs/research/ACGS-PGP_Framework/manual_compilation_guide.md
@@ -7,7 +7,8 @@ This guide provides step-by-step instructions for compiling the ACGS-PGP paper m
 You'll need:
 
 1. **LaTeX Distribution**: TeX Live (Linux/Mac) or MiKTeX (Windows)
-2. **Image Conversion Tool**: One of the following:
+2. **ACM LaTeX Package**: Install the `acmart` class. On Debian/Ubuntu systems run `sudo apt-get install texlive-publishers` or use `tlmgr install acmart`.
+3. **Image Conversion Tool**: One of the following:
    - Mermaid CLI (`npm install -g @mermaid-js/mermaid-cli`)
    - Draw.io Desktop or web version
    - Any vector graphics editor (Inkscape, Adobe Illustrator, etc.)


### PR DESCRIPTION
## Summary
- install `texlive-publishers` to ensure `acmart.cls` is available in CI
- mention `acmart` dependency in manual LaTeX compilation guide

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_68435519998083288981e7d10faddf90