### PR TITLE
Fix LaTeX build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,12 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-publishers
+            texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-publishers
+          tlmgr init-usertree
+          tlmgr install algorithm2e
+
+      - name: Verify algorithm2e installation
+        run: tlmgr info algorithm2e
 
       - name: Compile LaTeX document
         run: |


### PR DESCRIPTION
## Summary
- install `algorithm2e` package in CI LaTeX job
- verify installation before building docs

## Testing
- `bash run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pytest', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68435aa7afd083288d1779ab933700da